### PR TITLE
Fix footer placement and closing tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,8 +48,8 @@
         </main>
 
     </div>
+    <footer>
+        <p>&copy; 2023 NGIP Agmark Ltd. All rights reserved.</p>
+    </footer>
 </body>
-<footer>
-    <p>&copy; 2023 NGIP Agmark Ltd. All rights reserved.</p>
-
 </html>


### PR DESCRIPTION
## Summary
- move the footer so it's inside `<body>`
- add missing `</footer>` and ensure closing `</html>` tag

## Testing
- `python3 - <<'EOF'
from html.parser import HTMLParser
class MyParser(HTMLParser):
    def error(self, message):
        print('error:', message)
open('index.html').read()
parser = MyParser()
parser.feed(open('index.html').read())
print('parsed')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6854f47511b08325b9d745da5ed911f1